### PR TITLE
Add support for encrypted files

### DIFF
--- a/libraries/decrypt.rb
+++ b/libraries/decrypt.rb
@@ -1,0 +1,23 @@
+require 'openssl'
+require 'base64'
+
+class Citadel
+  class CitadelError < Exception; end
+
+  module Decrypt
+    extend self
+
+    def new(encrypted, key)
+      begin
+        cipher = OpenSSL::Cipher.new('aes-256-cbc')
+        cipher.decrypt
+        cipher.key = key
+
+        return cipher.update(Base64.decode64(encrypted)) + cipher.final
+      rescue Exception => e
+        raise CitadelError, "Unable to decrypt: #{e}"
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
### What does this PR do?

This PR allows citadel to load encrypted files from S3.
### How does it work?

Files should be uploaded to S3 encrypted with a secret key.

Here is an example on how to encrypt a string:

```
require 'openssl'
require "base64"

cipher = OpenSSL::Cipher.new('aes-256-cbc')
cipher.encrypt
cipher.key = "password"
puts cipher.update("secure string") + cipher.final
```
