### PR TITLE
Support IAM credentials direct from the EC2 metadata service

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source "https://supermarket.chef.io"
 
 metadata
 

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,10 +1,11 @@
-{
-  "sources": {
-    "citadel": {
-      "path": "."
-    },
-    "citadel_test": {
-      "path": "./test/cookbooks/citadel_test"
-    }
-  }
-}
+DEPENDENCIES
+  citadel
+    path: .
+    metadata: true
+  citadel_test
+    path: test/cookbooks/citadel_test
+
+GRAPH
+  citadel (1.1.0)
+  citadel_test (0.0.0)
+    citadel (>= 0.0.0)

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -27,6 +27,10 @@ class Citadel
       # Manually specified credentials
       @access_key_id = node['citadel']['access_key_id']
       @secret_access_key = node['citadel']['secret_access_key']
+    elsif creds = iam_credentials_from_metadata_service
+      @access_key_id = creds['AccessKeyId']
+      @secret_access_key = creds['SecretAccessKey']
+      @token = creds['Token']
     elsif node['ec2'] && node['ec2']['iam'] && node['ec2']['iam']['security-credentials']
       # Creds loaded from EC2 metadata server
       # This doesn't yet handle expiration, but it should
@@ -42,6 +46,16 @@ class Citadel
   def [](key)
     Chef::Log.debug("citadel: Retrieving #{@bucket}/#{key}")
     Citadel::S3.get(@bucket, key, @access_key_id, @secret_access_key, @token).to_s
+  end
+
+  def iam_credentials_from_metadata_service
+    require 'open-uri'
+    require 'json'
+
+    iam_role = open("http://169.254.169.254/latest/meta-data/iam/security-credentials/").read
+
+    JSON.parse(open("http://169.254.169.254/latest/meta-data/iam/security-credentials/#{iam_role}").read)
+
   end
 
   # Helper module for the DSL extension

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -49,13 +49,13 @@ class Citadel
   end
 
   def iam_credentials_from_metadata_service
-    require 'open-uri'
     require 'json'
 
-    iam_role = open("http://169.254.169.254/latest/meta-data/iam/security-credentials/").read
+    metadata_service = Chef::HTTP.new("http://169.254.169.254")
+    iam_role   = metadata_service.get("latest/meta-data/iam/security-credentials/")
+    creds_json = metadata_service.get("latest/meta-data/iam/security-credentials/#{iam_role}")
 
-    JSON.parse(open("http://169.254.169.254/latest/meta-data/iam/security-credentials/#{iam_role}").read)
-
+    JSON.parse(creds_json)
   end
 
   # Helper module for the DSL extension

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,7 +17,7 @@
 #
 
 name 'citadel'
-version '1.0.2'
+version '1.1.0'
 
 maintainer 'Noah Kantrowitz'
 maintainer_email 'noah@coderanger.net'

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -17,8 +17,7 @@
 #
 
 require 'serverspec'
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+set :backend, :exec
 
 describe file('/a') do
   its(:content) { should == 'citadel' }


### PR DESCRIPTION
While trying to bootstrap a new node in a private VPC subnet (unattended, using user data, not using `knife ec2` or similar), I found I was getting credential lookup failures at compile time as there was no node[:ec2] data, even after creating the hints file.

Rather than rely on Chef to be a credential concierge, I've added the ability to query the local metadata service directly, which is working nicely and has no reliance on run order or OHAI. This also ought to sidestep the slim chance of node data being out of date after credential rotation.

I've also brought the Berksfile up to date and made the tests pass with the latest serverspec v2+